### PR TITLE
Prevents a warning in PHP 8.1 - BN class uses ReturnTypeWillChange attribute on jsonSerialize

### DIFF
--- a/lib/BN.php
+++ b/lib/BN.php
@@ -92,6 +92,7 @@ class BN implements JsonSerializable
         return $this->bi->toNumber();
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize() {
         return $this->toString(16);
     }


### PR DESCRIPTION
Prevents a warning in PHP 8.1
Adding mixed return type would require php 8.0

lib/BN.php modified: add attribute

Fixes https://github.com/simplito/bn-php/issues/1