### PR TITLE
Checks for PHP Version when using (deprecated) assert_options

### DIFF
--- a/lib/BN.php
+++ b/lib/BN.php
@@ -163,7 +163,7 @@ class BN implements JsonSerializable
     }
 
     public function ior(BN $num) {
-        if (assert_options(ASSERT_ACTIVE)) assert(!$this->negative() && !$num->negative());
+        if (PHP_VERSION_ID < 80300 && assert_options(ASSERT_ACTIVE)) assert(!$this->negative() && !$num->negative());
         return $this->iuor($num);
     }
 
@@ -187,7 +187,7 @@ class BN implements JsonSerializable
     }
 
     public function iand(BN $num) {
-        if (assert_options(ASSERT_ACTIVE)) assert(!$this->negative() && !$num->negative());
+        if (PHP_VERSION_ID < 80300 && assert_options(ASSERT_ACTIVE)) assert(!$this->negative() && !$num->negative());
         return $this->iuand($num);
     }
 
@@ -211,7 +211,7 @@ class BN implements JsonSerializable
     }
 
     public function ixor(BN $num) {
-        if (assert_options(ASSERT_ACTIVE)) assert(!$this->negative() && !$num->negative());
+        if (PHP_VERSION_ID < 80300 && assert_options(ASSERT_ACTIVE)) assert(!$this->negative() && !$num->negative());
         return $this->iuxor($num);
     }
 
@@ -349,7 +349,7 @@ class BN implements JsonSerializable
     }
 
     public function ishln($bits) {
-        if (assert_options(ASSERT_ACTIVE)) assert(!$this->negative());
+        if (PHP_VERSION_ID < 80300 && assert_options(ASSERT_ACTIVE)) assert(!$this->negative());
         return $this->iushln($bits);
     }
 
@@ -374,7 +374,7 @@ class BN implements JsonSerializable
     }
 
     public function ishrn($bits, $hint = null, $extended = null) {
-        if (assert_options(ASSERT_ACTIVE)) assert(!$this->negative());
+        if (PHP_VERSION_ID < 80300 && assert_options(ASSERT_ACTIVE)) assert(!$this->negative());
         return $this->iushrn($bits, $hint, $extended);
     }
 
@@ -405,7 +405,7 @@ class BN implements JsonSerializable
     // Return only lowers bits of number (in-place)
     public function imaskn($bits) {
         assert(is_integer($bits) && $bits >= 0);
-        if (assert_options(ASSERT_ACTIVE)) assert(!$this->negative());
+        if (PHP_VERSION_ID < 80300 && assert_options(ASSERT_ACTIVE)) assert(!$this->negative());
         $mask = "";
         for($i = 0; $i < $bits; $i++)
             $mask .= "1";
@@ -455,7 +455,7 @@ class BN implements JsonSerializable
 
     // Find `this` / `num`
     public function div(BN $num) {
-        if (assert_options(ASSERT_ACTIVE)) assert(!$num->isZero());
+        if (PHP_VERSION_ID < 80300 && assert_options(ASSERT_ACTIVE)) assert(!$num->isZero());
         $res = clone($this);
         $res->bi = $res->bi->div($num->bi);
         return $res;
@@ -463,14 +463,14 @@ class BN implements JsonSerializable
 
     // Find `this` % `num`
     public function mod(BN $num) {
-        if (assert_options(ASSERT_ACTIVE)) assert(!$num->isZero());
+        if (PHP_VERSION_ID < 80300 && assert_options(ASSERT_ACTIVE)) assert(!$num->isZero());
         $res = clone($this);
         $res->bi = $res->bi->divR($num->bi);
         return $res;
     }
 
     public function umod(BN $num) {
-        if (assert_options(ASSERT_ACTIVE)) assert(!$num->isZero());
+        if (PHP_VERSION_ID < 80300 && assert_options(ASSERT_ACTIVE)) assert(!$num->isZero());
         $tmp = $num->bi->sign() < 0 ? $num->bi->abs() : $num->bi;        
         $res = clone($this);
         $res->bi = $this->bi->mod($tmp);
@@ -480,7 +480,7 @@ class BN implements JsonSerializable
     // Find Round(`this` / `num`)
     public function divRound(BN $num)
     {
-        if (assert_options(ASSERT_ACTIVE)) assert(!$num->isZero());
+        if (PHP_VERSION_ID < 80300 && assert_options(ASSERT_ACTIVE)) assert(!$num->isZero());
 
         $negative = $this->negative() !== $num->negative();
 

--- a/lib/Red.php
+++ b/lib/Red.php
@@ -38,13 +38,13 @@ class Red
 
     public function verify1(BN $num)
     {        
-        if (assert_options(ASSERT_ACTIVE)) assert(!$num->negative()); //,"red works only with positives");
+        if (PHP_VERSION_ID < 80300 && assert_options(ASSERT_ACTIVE)) assert(!$num->negative()); //,"red works only with positives");
         assert($num->red); //, "red works only with red numbers");
     }
 
     public function verify2(BN $a, BN $b)
     {
-        if (assert_options(ASSERT_ACTIVE)) assert(!$a->negative() && !$b->negative()); //, "red works only with positives");
+        if (PHP_VERSION_ID < 80300 && assert_options(ASSERT_ACTIVE)) assert(!$a->negative() && !$b->negative()); //, "red works only with positives");
         assert($a->red && ($a->red == $b->red)); //, "red works only with red numbers");
     }
 
@@ -150,7 +150,7 @@ class Red
             $s++;
             $q->iushrn(1);
         }
-        if (assert_options(ASSERT_ACTIVE)) assert(!$q->isZero());
+        if (PHP_VERSION_ID < 80300 && assert_options(ASSERT_ACTIVE)) assert(!$q->isZero());
 
         $one = (new BN(1))->toRed($this);
         $nOne = $one->redNeg();


### PR DESCRIPTION
PHP 8.3 displays a deprecation message for `assert_options()`, which will be gone as of PHP 9. This is a backwards compatible fix, checking for PHP version before performing `assert_options()`.  As of PHP 9.3 `assert()` implicitly checks wether to use or skip `assert()`, so this operations becomes redundant.